### PR TITLE
Fixed swagger link

### DIFF
--- a/platform.ultri.com/docs/ultri-open-platform/index.md
+++ b/platform.ultri.com/docs/ultri-open-platform/index.md
@@ -22,4 +22,4 @@ The API exposes the [Nugget Schema](/nugget-schema/).
 
 ### Swagger
 
-The [live swagger](https://api.service.ultri.com/documentation/) spec is available.
+The [live swagger](https://api.service.ultri.com/documentation) spec is available.

--- a/platform.ultri.com/docs/ultri-open-platform/index.md
+++ b/platform.ultri.com/docs/ultri-open-platform/index.md
@@ -22,4 +22,4 @@ The API exposes the [Nugget Schema](/nugget-schema/).
 
 ### Swagger
 
-The [live swagger](https://api.service.ultri.com) spec is available.
+The [live swagger](https://api.service.ultri.com/documentation/) spec is available.


### PR DESCRIPTION
Added /documentation/ to the link to make the unauthorized access error go away